### PR TITLE
Real-time visualisation of distance estimation - Validated

### DIFF
--- a/app/src/main/java/com/vmware/herald/app/MainActivity.java
+++ b/app/src/main/java/com/vmware/herald/app/MainActivity.java
@@ -24,10 +24,24 @@ import com.vmware.herald.sensor.Sensor;
 import com.vmware.herald.sensor.SensorArray;
 import com.vmware.herald.sensor.SensorDelegate;
 import com.vmware.herald.sensor.analysis.SocialDistance;
+import com.vmware.herald.sensor.analysis.algorithms.distance.SmoothedLinearModelAnalyser;
+import com.vmware.herald.sensor.analysis.sampling.AnalysisDelegate;
+import com.vmware.herald.sensor.analysis.sampling.AnalysisDelegateManager;
+import com.vmware.herald.sensor.analysis.sampling.AnalysisProviderManager;
+import com.vmware.herald.sensor.analysis.sampling.AnalysisRunner;
+import com.vmware.herald.sensor.analysis.sampling.ConcreteAnalysisDelegate;
+import com.vmware.herald.sensor.analysis.sampling.Sample;
+import com.vmware.herald.sensor.analysis.sampling.SampleList;
+import com.vmware.herald.sensor.analysis.sampling.SampledID;
+import com.vmware.herald.sensor.analysis.views.Since;
+import com.vmware.herald.sensor.datatype.Distance;
+import com.vmware.herald.sensor.datatype.DoubleValue;
 import com.vmware.herald.sensor.datatype.ImmediateSendData;
 import com.vmware.herald.sensor.datatype.Location;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.Proximity;
+import com.vmware.herald.sensor.datatype.ProximityMeasurementUnit;
+import com.vmware.herald.sensor.datatype.RSSI;
 import com.vmware.herald.sensor.datatype.SensorState;
 import com.vmware.herald.sensor.datatype.SensorType;
 import com.vmware.herald.sensor.datatype.TargetIdentifier;
@@ -66,6 +80,12 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
     // MARK:- Social mixing
     private final SocialDistance socialMixingScore = new SocialDistance();
     private TimeInterval socialMixingScoreUnit = new TimeInterval(60);
+
+    // MARK:- Distance estimation
+    private final AnalysisProviderManager analysisProviderManager = new AnalysisProviderManager(new SmoothedLinearModelAnalyser());
+    private final ConcreteAnalysisDelegate<Distance> analysisDelegate = new ConcreteAnalysisDelegate<>(Distance.class, 5);
+    private final AnalysisDelegateManager analysisDelegateManager = new AnalysisDelegateManager(analysisDelegate);
+    private final AnalysisRunner analysisRunner = new AnalysisRunner(analysisProviderManager, analysisDelegateManager, 120);
 
 
     @Override
@@ -167,6 +187,15 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
                 return t0.payloadData().shortName().compareTo(t1.payloadData().shortName());
             }
         });
+        // Get target distance from analysis delegate
+        for (final Target target : targetList) {
+            if (target.payloadData() == null) {
+                continue;
+            }
+            final SampledID sampledID = new SampledID(target.payloadData());
+            final SampleList<Distance> sampleList = analysisDelegate.samples(sampledID);
+            target.distance(sampleList.filter(Since.recent(90)).toView().latestValue());
+        }
         // Update UI
         ((TextView) findViewById(R.id.detection)).setText("DETECTION (" + targetListAdapter.getCount() + ")");
         targetListAdapter.clear();
@@ -333,6 +362,15 @@ public class MainActivity extends AppCompatActivity implements SensorDelegate, A
             if (target != null) {
                 target.targetIdentifier(fromTarget);
                 target.proximity(didMeasure);
+                // Supply raw RSSI measurements to distance estimation algorithm
+                if (didMeasure.unit == ProximityMeasurementUnit.RSSI) {
+                    final SampledID sampledID = new SampledID(didRead);
+                    analysisRunner.newSample(sampledID, new Sample<>(new RSSI((int) Math.round(didMeasure.value))));
+                    // Analysis runner doesn't need to be executed as often as updates
+                    // but the overhead is minimal as the demonstration distance analyser
+                    // will only perform calculations and offer updates at fixed intervals
+                    analysisRunner.run();
+                }
             }
         }
         if (foreground) {

--- a/app/src/main/java/com/vmware/herald/app/Target.java
+++ b/app/src/main/java/com/vmware/herald/app/Target.java
@@ -6,6 +6,7 @@ package com.vmware.herald.app;
 
 import com.vmware.herald.sensor.analysis.Sample;
 import com.vmware.herald.sensor.datatype.Data;
+import com.vmware.herald.sensor.datatype.Distance;
 import com.vmware.herald.sensor.datatype.ImmediateSendData;
 import com.vmware.herald.sensor.datatype.PayloadData;
 import com.vmware.herald.sensor.datatype.Proximity;
@@ -19,6 +20,7 @@ public class Target {
     private PayloadData payloadData = null;
     private Date lastUpdatedAt = null;
     private Proximity proximity = null;
+    private Distance distance = null;
     private ImmediateSendData received = null;
     private Date didRead = null, didMeasure = null, didShare = null, didReceive = null;
     private Sample didReadTimeInterval = new Sample();
@@ -62,6 +64,12 @@ public class Target {
         lastUpdatedAt = date;
         didMeasure = lastUpdatedAt;
         this.proximity = proximity;
+    }
+
+    public Distance distance() { return distance; }
+
+    public void distance(Distance distance) {
+        this.distance = distance;
     }
 
     public ImmediateSendData received() {

--- a/app/src/main/java/com/vmware/herald/app/TargetListAdapter.java
+++ b/app/src/main/java/com/vmware/herald/app/TargetListAdapter.java
@@ -54,13 +54,21 @@ public class TargetListAdapter extends ArrayAdapter<Target> {
             statistics.append(",S=");
             statistics.append(decimalFormat.format(target.didShareTimeInterval().mean()) + "s");
         }
+        // Distance
+        final StringBuilder distance = new StringBuilder();
+        if (target.distance() != null) {
+            distance.append(String.format("%.2fm", target.distance().value));
+        }
         final StringBuilder labelText = new StringBuilder(target.payloadData().shortName());
         if (target.payloadData() instanceof LegacyPayloadData) {
             labelText.append(':');
             labelText.append(((LegacyPayloadData) target.payloadData()).protocolName().name().charAt(0));
         }
+        if (!distance.toString().isEmpty()) {
+            labelText.append(" - ");
+            labelText.append(distance.toString());
+        }
         final String didReceive = (target.didReceive() == null ? "" : " (receive " + dateFormatterTime.format(target.didReceive()) + ")");
-        final String protocolSuffix = (target.payloadData() instanceof LegacyPayloadData ? ":" + ((LegacyPayloadData) target.payloadData()).protocolName().name().substring(0,1) : "");
         textLabel.setText(labelText.toString() + didReceive);
         detailedTextLabel.setText(dateFormatter.format(target.lastUpdatedAt()) + " [" + statistics.toString() + "]");
         return convertView;

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Gaussian.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Gaussian.java
@@ -29,7 +29,7 @@ public class Gaussian<T extends DoubleValue> implements Aggregate<T> {
     }
 
     @Override
-    public double reduce() {
+    public Double reduce() {
         return model.mean();
     }
 

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Mean.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Mean.java
@@ -31,7 +31,7 @@ public class Mean<T extends DoubleValue> implements Aggregate<T> {
     }
 
     @Override
-    public double reduce() {
+    public Double reduce() {
         return sum / count;
     }
 

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Median.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Median.java
@@ -35,7 +35,7 @@ public class Median<T extends DoubleValue> implements Aggregate<T> {
     }
 
     @Override
-    public double reduce() {
+    public Double reduce() {
         return median();
     }
 
@@ -55,13 +55,16 @@ public class Median<T extends DoubleValue> implements Aggregate<T> {
         }
     }
 
-    private double median() {
-        double median;
+    private Double median() {
         if (minHeap.size() > maxHeap.size()) {
-            median = minHeap.peek();
+            return minHeap.peek();
         } else {
-            median = (minHeap.peek() + maxHeap.peek()) / 2;
+            final Double min = minHeap.peek();
+            final Double max = maxHeap.peek();
+            if (min != null && max != null) {
+                return (min + max) / 2;
+            }
+            return null;
         }
-        return median;
     }
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Mode.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Mode.java
@@ -40,7 +40,10 @@ public class Mode<T extends DoubleValue> implements Aggregate<T> {
     }
 
     @Override
-    public double reduce() {
+    public Double reduce() {
+        if (counts.isEmpty()) {
+            return null;
+        }
         double largest = 0;
         long largestCount = 0;
         for (Map.Entry<Double,Counter> entry : counts.entrySet()) {

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Variance.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/aggregates/Variance.java
@@ -44,9 +44,9 @@ public class Variance<T extends DoubleValue> implements Aggregate<T> {
     }
 
     @Override
-    public double reduce() {
+    public Double reduce() {
         if (count < 1) {
-            return 0; // div by zero check
+            return 0d;
         }
         return sum / (count - 1); // Sample variance
     }

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/algorithms/distance/FowlerBasic.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/algorithms/distance/FowlerBasic.java
@@ -40,7 +40,7 @@ public class FowlerBasic<T extends DoubleValue> implements Aggregate<T> {
    }
 
     @Override
-    public double reduce() {
+    public Double reduce() {
         final double exponent = (mode.reduce() - intercept) / coefficient;
         return Math.pow(10, exponent);
     }

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/algorithms/distance/SmoothedLinearModelAnalyser.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/algorithms/distance/SmoothedLinearModelAnalyser.java
@@ -10,29 +10,30 @@ import com.vmware.herald.sensor.analysis.sampling.Filter;
 import com.vmware.herald.sensor.analysis.sampling.Sample;
 import com.vmware.herald.sensor.analysis.sampling.SampleList;
 import com.vmware.herald.sensor.analysis.sampling.SampledID;
-import com.vmware.herald.sensor.analysis.views.InPeriod;
 import com.vmware.herald.sensor.analysis.views.InRange;
+import com.vmware.herald.sensor.analysis.views.Since;
+import com.vmware.herald.sensor.data.ConcreteSensorLogger;
+import com.vmware.herald.sensor.data.SensorLogger;
 import com.vmware.herald.sensor.datatype.Date;
 import com.vmware.herald.sensor.datatype.Distance;
 import com.vmware.herald.sensor.datatype.RSSI;
 import com.vmware.herald.sensor.datatype.TimeInterval;
 
 public class SmoothedLinearModelAnalyser implements AnalysisProvider<RSSI, Distance> {
+    private final SensorLogger logger = new ConcreteSensorLogger("Analysis", "SmoothedLinearModelAnalyser");
     private final TimeInterval interval;
     private final TimeInterval smoothingWindow;
-    private final long halfOfSmoothingWindow;
     private final SmoothedLinearModel model;
     private Date lastRan = new Date(0);
     private final Filter<RSSI> valid = new InRange<>(-99, -10);
 
     public SmoothedLinearModelAnalyser() {
-        this(10, TimeInterval.minute, -17.7275, -0.2754);
+        this(1, TimeInterval.seconds(60), -10.6522, -0.181);
     }
 
     public SmoothedLinearModelAnalyser(final long interval, final TimeInterval smoothingWindow, final double intercept, final double coefficient) {
         this.interval = new TimeInterval(interval);
         this.smoothingWindow = smoothingWindow;
-        this.halfOfSmoothingWindow = smoothingWindow.value / 2;
         this.model = new SmoothedLinearModel(intercept, coefficient);
     }
 
@@ -49,29 +50,42 @@ public class SmoothedLinearModelAnalyser implements AnalysisProvider<RSSI, Dista
     @Override
     public boolean analyse(Date timeNow, SampledID sampled, SampleList<RSSI> input, final SampleList<Distance> output, CallableForNewSample<Distance> callable) {
         // Interval guard
-        if (lastRan.secondsSinceUnixEpoch() + interval.value >= timeNow.secondsSinceUnixEpoch()) {
+        final TimeInterval secondsSinceLastRan = new TimeInterval(timeNow.secondsSinceUnixEpoch() - lastRan.secondsSinceUnixEpoch());
+        if (secondsSinceLastRan.value < interval.value) {
+            logger.debug("analyse, skipped (reason=elapsedSinceLastRanBelowInterval,interval={}s,timeSinceLastRan={}s,lastRan={})", interval, secondsSinceLastRan, lastRan);
             return false;
         }
-        // Input guard : Must have data to analyse
-        if (input.size() == 0) {
+        // Input guard : Must have valid data to analyse
+        final SampleList<RSSI> validInput = input.filter(valid).toView();
+        if (validInput.size() == 0) {
+            logger.debug("analyse, skipped (reason=noValidData,inputSamples={},validInputSamples={})", input.size(), validInput.size());
             return false;
         }
-        // Smoothing window guard : Look ahead for 1/2 of smoothing window duration
-        if (input.latest().secondsSinceUnixEpoch() - timeNow.secondsSinceUnixEpoch() < halfOfSmoothingWindow) {
+        // Input guard : Must cover entire smoothing window
+        final TimeInterval observed = new TimeInterval(timeNow.secondsSinceUnixEpoch() - validInput.get(0).taken().secondsSinceUnixEpoch());
+        if (observed.value < smoothingWindow.value) {
+            logger.debug("analyse, skipped (reason=insufficientHistoricDataForSmoothing,required={}s,observed={}s)", smoothingWindow, observed);
             return false;
         }
-        // Smoothing window guard : Look behind for 1/2 of smoothing window duration
-        if (timeNow.secondsSinceUnixEpoch() - input.get(0).taken().secondsSinceUnixEpoch() < halfOfSmoothingWindow) {
+        // Input guard : Must have sufficient data in smoothing window
+        final SampleList<RSSI> window = validInput.filter(new Since<>(timeNow.secondsSinceUnixEpoch() - smoothingWindow.value)).toView();
+        if (window.size() < 5) {
+            logger.debug("analyse, skipped (reason=insufficientDataInSmoothingWindow,minimum=5,samplesInWindow={})", window.size());
             return false;
         }
-        // Only consider valid samples within smoothing window
-        model.reset();
-        final Filter<RSSI> inSmoothingWindow = new InPeriod<>(timeNow.secondsSinceUnixEpoch() - halfOfSmoothingWindow, timeNow.secondsSinceUnixEpoch() + halfOfSmoothingWindow);
-        final SampleList<RSSI> window = input.filter(valid).filter(inSmoothingWindow).toView();
         // Estimate distance based on smoothed linear model
-        final double distance = window.aggregate(model).get(SmoothedLinearModel.class);
+        model.reset();
+        final Double distance = window.aggregate(model).get(SmoothedLinearModel.class);
+        if (distance == null) {
+            logger.debug("analyse, skipped (reason=outOfModelRange,mediaOfRssi={},maximumRssiAtZeroDistance={})", model.medianOfRssi(), model.maximumRssi());
+            return false;
+        }
         // Publish distance data
-        final Sample<Distance> newSample = new Sample<>(timeNow, new Distance(distance));
+        final Date timeStart = window.get(0).taken();
+        final Date timeEnd = window.latest();
+        final Date timeMiddle = new Date(timeEnd.secondsSinceUnixEpoch() - ((timeEnd.secondsSinceUnixEpoch() - timeStart.secondsSinceUnixEpoch()) / 2));
+        logger.debug("analyse (timeStart={},timeEnd={},timeMiddle={},samples={},medianOfRssi={},distance={})", timeStart, timeEnd, timeMiddle, window.size(), model.medianOfRssi(), distance);
+        final Sample<Distance> newSample = new Sample<>(timeEnd, new Distance(distance));
         output.push(newSample);
         callable.newSample(sampled, newSample);
         return true;

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/algorithms/risk/RiskAggregationBasic.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/algorithms/risk/RiskAggregationBasic.java
@@ -68,7 +68,7 @@ public class RiskAggregationBasic<T extends DoubleValue> implements Aggregate<T>
    }
 
     @Override
-    public double reduce() {
+    public Double reduce() {
         if (-1.0 != nMinusOne) {
             // we have two values with which to calculate
             // using nMinusOne and n, and calculate interim risk score addition

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/Aggregate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/Aggregate.java
@@ -13,7 +13,7 @@ public interface Aggregate<T extends DoubleValue> {
 
     void map(Sample<T> value);
 
-    double reduce();
+    Double reduce();
 
     void reset();
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/AnalysisRunner.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/AnalysisRunner.java
@@ -4,10 +4,13 @@
 
 package com.vmware.herald.sensor.analysis.sampling;
 
+import com.vmware.herald.sensor.data.ConcreteSensorLogger;
+import com.vmware.herald.sensor.data.SensorLogger;
 import com.vmware.herald.sensor.datatype.Date;
 import com.vmware.herald.sensor.datatype.DoubleValue;
 
 public class AnalysisRunner {
+    private final SensorLogger logger = new ConcreteSensorLogger("Analysis", "AnalysisRunner");
     private final AnalysisProviderManager analysisProviderManager;
     private final AnalysisDelegateManager analysisDelegateManager;
     private final VariantSet variantSet;
@@ -24,6 +27,10 @@ public class AnalysisRunner {
 
     public <T extends DoubleValue> void newSample(SampledID sampled, Sample<T> item) {
         variantSet.push(sampled, item);
+    }
+
+    public void run() {
+        run(new Date());
     }
 
     public void run(Date timeNow) {

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/ConcreteAnalysisDelegate.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/ConcreteAnalysisDelegate.java
@@ -1,0 +1,44 @@
+//  Copyright 2021 Herald Project Contributors
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+package com.vmware.herald.sensor.analysis.sampling;
+
+import com.vmware.herald.sensor.datatype.DoubleValue;
+
+public class ConcreteAnalysisDelegate<T extends DoubleValue> implements AnalysisDelegate<T> {
+    private final Class<T> inputType;
+    private final ListManager<T> listManager;
+    private final SampleList<T> sampleList;
+
+    public ConcreteAnalysisDelegate(final Class<T> inputType, final int listSize) {
+        this.inputType = inputType;
+        this.listManager = new ListManager<>(listSize);
+        this.sampleList = new SampleList<>(listSize);
+    }
+
+    @Override
+    public Class<T> inputType() {
+        return inputType;
+    }
+
+    @Override
+    public void reset() {
+        listManager.clear();
+    }
+
+    @Override
+    public SampleList<T> samples() {
+        return sampleList;
+    }
+
+    public SampleList<T> samples(final SampledID sampledID) {
+        return listManager.list(sampledID);
+    }
+
+    @Override
+    public void newSample(SampledID sampled, Sample<T> item) {
+        listManager.push(sampled, item);
+        sampleList.push(item);
+    }
+}

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/ListManager.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/ListManager.java
@@ -45,4 +45,8 @@ public class ListManager<T extends DoubleValue> {
     public synchronized void clear() {
         map.clear();
     }
+
+    public synchronized void push(final SampledID sampledID, final Sample<T> sample) {
+        list(sampledID).push(sample);
+    }
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/Sample.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/Sample.java
@@ -27,6 +27,11 @@ public class Sample<T> {
         this.value = other.value;
     }
 
+    public Sample(final T value) {
+        this.taken = new Date();
+        this.value = value;
+    }
+
     public Date taken() {
         return taken;
     }

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/SampleList.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/SampleList.java
@@ -119,6 +119,12 @@ public class SampleList<T extends DoubleValue> implements Iterable<Sample<T>>, F
         return data[newestPosition].taken();
     }
 
+    public T latestValue() {
+        if (newestPosition == data.length) {
+            return null;
+        }
+        return (T) data[newestPosition].value();
+    }
 
     private void incrementNewest() {
         if (newestPosition == data.length) {

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/SampledID.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/SampledID.java
@@ -4,6 +4,9 @@
 
 package com.vmware.herald.sensor.analysis.sampling;
 
+import com.vmware.herald.sensor.datatype.Data;
+import com.vmware.herald.sensor.datatype.Int64;
+
 import java.util.Objects;
 
 public class SampledID implements Comparable<SampledID> {
@@ -11,6 +14,18 @@ public class SampledID implements Comparable<SampledID> {
 
     public SampledID(long value) {
         this.value = value;
+    }
+
+    public SampledID(Data data) {
+        final Data hashValue = new Data();
+        hashValue.append(new Int64(0));
+        for (int i=0, j=0; i<data.value.length; i++, j++) {
+            if (j >= 8) {
+                j = 0;
+            }
+            hashValue.value[j] = (byte) (hashValue.value[j] ^ data.value[i]);
+        }
+        this.value = hashValue.int64(0).value;
     }
 
     @Override
@@ -28,9 +43,7 @@ public class SampledID implements Comparable<SampledID> {
 
     @Override
     public String toString() {
-        return "SampledID{" +
-                "value=" + value +
-                '}';
+        return Long.toString(value);
     }
 
     @Override

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/Summary.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/Summary.java
@@ -13,19 +13,19 @@ public class Summary<T extends DoubleValue> {
         this.aggregates = aggregates;
     }
 
-    public double get(final Class<? extends Aggregate> byClass) {
+    public Double get(final Class<? extends Aggregate> byClass) {
         for (int i=0; i<aggregates.length; i++) {
             if (byClass.isInstance(aggregates[i])) {
                 return aggregates[i].reduce();
             }
         }
-        return 0;
+        return null;
     }
 
-    public double get(final int index) {
+    public Double get(final int index) {
         if (index < 0 || index >= aggregates.length) {
             // Index out of bounds
-            return 0;
+            return null;
         }
         return aggregates[index].reduce();
     }

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/VariantSet.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/sampling/VariantSet.java
@@ -67,6 +67,6 @@ public class VariantSet {
     }
 
     public <T extends DoubleValue> void push(final SampledID sampledID, final Sample<T> sample) {
-        ((SampleList<T>) listManager(sample.value().getClass(), sampledID)).push(sample);
+        ((ListManager<T>) listManager(sample.value().getClass())).push(sampledID, sample);
     }
 }

--- a/herald/src/main/java/com/vmware/herald/sensor/analysis/views/Since.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/analysis/views/Since.java
@@ -22,6 +22,10 @@ public class Since<T extends DoubleValue> implements Filter<T> {
         this.afterTime = after.getTime();
     }
 
+    public final static <T extends DoubleValue> Since<T> recent(final long inLastSeconds) {
+        return new Since(new Date().secondsSinceUnixEpoch() - inLastSeconds);
+    }
+
     @Override
     public boolean test(Sample<T> item) {
         return item.taken().getTime() >= afterTime;

--- a/herald/src/main/java/com/vmware/herald/sensor/datatype/Date.java
+++ b/herald/src/main/java/com/vmware/herald/sensor/datatype/Date.java
@@ -15,6 +15,7 @@ public class Date extends java.util.Date {
     }
 
     public Date() {
+        super();
     }
 
     public Date(final java.util.Date date) {


### PR DESCRIPTION
- Near real-time display of estimated distance per device on user interface
  - Model requires at least 60 seconds of historic data (no data on display otherwise)
  - Distance < 20cm is out of model range (no data on display)
  - Displayed distance is up to 90 seconds in the past
- Distance estimation based on RSSI measurements using Smoothed Linear Model
  - Model parameters obtained through linear regression of circa 751k RSSI-distance samples
  - Sample data captured from 10 different iOS and Android phones using Test Rig 2 for range 0 to 3.4 metres at 1cm resolution (circa 60 samples per 1cm)
  - Updated model and parameters
  - R-squared error is 0.88cm
- Model is only valid under the following conditions:
  - Distances greater than 20cm (else display will not show distance)
  - Phones are **NOT** perfectly static (i.e. placed on desk for artificial tests)
  - Model assumes phones are being carried on person and moving slightly all the time
  - Movement (only < 6cm range required) is essential for creating random interferences
  - Model is designed to expect random interferences for cancellation
- Validated using Pixel2 and Pixel3

Signed-off-by: c19x <support@c19x.org>