### PR TITLE
Fixes #152. Added CI unit test checks for all PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,25 @@
+# How GitHub Actions is used
+
+We aim to have the following steps:-
+
+- Unit tests check on PR being issued to Develop or master/main branches
+  - unit_tests.yml
+  - Prevents regressions
+  - Also useful incase a develop forgets to run locally, or thinks "It's just a doc change, it'll be fine"
+
+Currently not done:-
+
+- No automation to auto release when a mileston is complete - requires manual PR from develop to master, and manual release notes with 'v' tag
+- No code coverage for tests
+- No multi-android version tests
+- We don't automatically retest existing code when a new android version is released (We should probably do this for every single beta release and full release)
+
+
+Later:-
+
+
+- Build release on seeins a 'v' tag (E.g. v2.1)
+  - see https://www.raywenderlich.com/19407406-continuous-delivery-for-android-using-github-actions
+  - issue_release.yml
+  - Build and sign final APK for statically linked Herald library
+  - Build and push maven release

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,17 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - develop # PRs from external developers or project team
+      - master  # PRs for triggering a release. Both old (master) and new (main) branch names
+      - main
+
+jobs:
+  unit_tests:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Unit tests
+        run: ./gradlew test


### PR DESCRIPTION
Fixes #152. Added CI unit test checks for all PRs
- Single latest android version for now
- Just basic unit tests, not android ui tests (It's for the library)
- No release build support yet
Signed-off-by: Adam Fowler <adam@adamfowler.org>