### PR TITLE
Check ManufacturerSpecificData for Android devices running SDK 28 or lower

### DIFF
--- a/herald/src/main/java/io/heraldprox/herald/sensor/ble/ConcreteBLEDatabase.java
+++ b/herald/src/main/java/io/heraldprox/herald/sensor/ble/ConcreteBLEDatabase.java
@@ -128,7 +128,7 @@ public class ConcreteBLEDatabase implements BLEDatabase, BLEDeviceDelegate {
     @Nullable
     private PseudoDeviceAddress pseudoDeviceAddress(@NonNull final ScanResult scanResult) {
         final ScanRecord scanRecord = scanResult.getScanRecord();
-        if (null == scanRecord) {
+        if (null == scanRecord || null == scanRecord.getManufacturerSpecificData()) {
             return null;
         }
         // Add external entropy to RandomSource


### PR DESCRIPTION
On very specific devices running Android 9 (SDK 28) or lower, this can trigger a NullPointerException.

Signed-off-by: David Joo <djoo@vmware.com>

Closes https://github.com/theheraldproject/herald-for-android/issues/217