### PR TITLE
Fixes #234. Added logging of seconds to three decimal places, and time zone

### DIFF
--- a/herald/src/main/java/io/heraldprox/herald/sensor/data/SensorDelegateLogger.java
+++ b/herald/src/main/java/io/heraldprox/herald/sensor/data/SensorDelegateLogger.java
@@ -20,7 +20,7 @@ import io.heraldprox.herald.sensor.DefaultSensorDelegate;
  * Default sensor delegate with convenient functions for writing data to log file.
  */
 public class SensorDelegateLogger extends DefaultSensorDelegate implements Resettable {
-    protected final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.UK);
+    protected final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ", Locale.UK);
     @Nullable
     protected final Context context;
     @Nullable

--- a/herald/src/main/java/io/heraldprox/herald/sensor/data/TextFile.java
+++ b/herald/src/main/java/io/heraldprox/herald/sensor/data/TextFile.java
@@ -277,16 +277,11 @@ public class TextFile implements Resettable {
         // Discard pending writes
         writeBuffer.clear();
         try {
-            // Write to temporary file first
-            final File temporaryFile = new File(file.getParentFile(), file.getName() + ".tmp");
-            final FileOutputStream fileOutputStream = new FileOutputStream(temporaryFile);
+            // No longer writing to temporary file first as this caused the test to fail on latest Android version
+            final FileOutputStream fileOutputStream = new FileOutputStream(file, false);
             fileOutputStream.write(content.getBytes());
             fileOutputStream.flush();
             fileOutputStream.close();
-            // Rename to actual file on completion
-            if (!temporaryFile.renameTo(file)) {
-                logger.fault("overwrite failed (file={},reason=renameFailed)", file);
-            }
         } catch (Throwable e) {
             logger.fault("overwrite failed (file={})", file, e);
         }


### PR DESCRIPTION
Added logging of seconds to three decimal places, and time zone
- Verified log format in contacts.log
- Verified callbacks are contemporaneous and not artificially delayed
- Note that this also affects battery.log
- Ran all tests which passed after one unrelated fix as below
- Stopped using temporary file in TextFile.reset() as the reset test was failing
Signed-off-by: Adam Fowler <adam@adamfowler.org>
